### PR TITLE
Changing seeds.py to seed.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You need to install the following tools:
 2. Copy env template `cp .env.example .env` then fill in missing keys
 3. Create database with `createdb igeretfigyelo`
 4. Load database schema with `psql -f db/schema.sql -d igeretfigyelo`
-5. Generate a sample database with `python db/seeds.py` (it will erase all existing data)
+5. Generate a sample database with `python db/seed.py` (it will erase all existing data)
 
 Default users are (email / password:
 * admin@example.com / LetMeIn


### PR DESCRIPTION
A db mappában seed.py fájl van; seeds.py-t említ a README, ezt a typo-t javítja ez a commit.